### PR TITLE
feat(nx-cloud): set up nx workspace

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -12,7 +12,7 @@
       "{workspaceRoot}/.gitlab-ci.yml"
     ]
   },
-  "nxCloudId": "67a0b8d23135fd1d9a1d8d19",
+  "nxCloudId": "67d0ea695126804933b6b7f9",
   "plugins": [
     "@monodon/rust"
   ]


### PR DESCRIPTION
feat(nx-cloud): setup nx cloud workspace

This commit sets up Nx Cloud for your Nx workspace, enabling distributed caching and the Nx Cloud GitHub integration for fast CI and improved developer experience.

You can access your Nx Cloud workspace by going to
https://cloud.nx.app/orgs/673eaa76406321e9b594d07e/workspaces/67d0ea695126804933b6b7f9

**Note:** This commit attempts to maintain formatting of the nx.json file, however you may need to correct formatting by running an nx format command and committing the changes.